### PR TITLE
docs: SQD rebrand + canonical doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-# EVM indexing squids
+# EVM / Ethereum indexer examples (Squid SDK)
 
-This repo contains sample [squid ETLs](https://docs.subsquid.io/overview/) for indexing, transforming and presenting EVM on-chain data as GraphQL APIs. Each squid highlights a specific feature of the Subquid SDK.
+This repo contains sample [squid ETLs](https://docs.sqd.dev/en/sdk/overview) for indexing, transforming and presenting EVM onchain data as GraphQL APIs. Each squid highlights a specific feature of the Squid SDK.
+
+## Documentation
+
+- Docs: https://docs.sqd.dev
+- Website: https://sqd.dev
 
 ## Overview
 
@@ -9,12 +14,12 @@ This repo contains sample [squid ETLs](https://docs.subsquid.io/overview/) for i
 - [3-factory](https://github.com/belopash/factory-example): Index token swaps within dynamically created pools. Illustrates network-wide filtering of EVM logs.
 - [4-contract-calls](https://github.com/belopash/contract-example): Enrich the model data by querying historical state of the contract.
 - [5-multicall](https://github.com/belopash/multicall-example): Same as the contract example but with state requests batching.
-- [6-ipfs](https://github.com/subsquid-labs/ipfs-example) A BAYC NFT indexer. Illustrates batched IPFS gateway calls, external API calls, and contract state queries. Alternative implementation of the [BAYC indexer](https://github.com/subsquid-labs/bayc-squid-1) described in the [tutorial](https://docs.subsquid.io/tutorials/bayc/).
+- [6-ipfs](https://github.com/subsquid-labs/ipfs-example) A BAYC NFT indexer. Illustrates batched IPFS gateway calls, external API calls, and contract state queries. Alternative implementation of the [BAYC indexer](https://github.com/subsquid-labs/bayc-squid-1) described in the [tutorial](https://docs.sqd.dev/en/sdk).
 - [7-multichain](https://github.com/subsquid-labs/multichain-transfers-example) A simple multichain squid indexing Transfer events emitted by USDC contracts on Ethereum and BSC.
 
 ## Prerequisites
 
-- Node v16.x
+- Node.js 20 or newer
 - Docker
 - Squid CLI
 


### PR DESCRIPTION
SEO cleanup: repoint legacy docs.subsquid.io links to verified docs.sqd.dev URLs, rebrand Subsquid -> SQD (and fix the "Subquid" typo), bump Node prerequisite to Node.js 20 or newer, add a Documentation section, and apply house style (onchain). Every link verified 200.

Changes:
- H1 made keyword-rich: "EVM / Ethereum indexer examples (Squid SDK)"
- 2 legacy docs.subsquid.io links repointed to verified docs.sqd.dev/en/sdk pages
- "Subquid SDK" typo -> "Squid SDK"; "on-chain" -> "onchain"
- Added Documentation section linking https://docs.sqd.dev and https://sqd.dev
- Node v16.x -> Node.js 20 or newer

GitHub example links were left as-is (all resolve 200; not legacy subsquid.io domains). No Gitpod/init/clone-URL or badge issues present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)